### PR TITLE
feat: Reply-To mismatch detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ gmail-sender-info/
 
 **Background → Content:** `{ available: true|false }`
 
-**Content → Background:** `{ action: 'analyzeEmail', data: { displayName, senderEmail, subject, bodyText, links, isEmptyBody, recipientStatus } }`
+**Content → Background:** `{ action: 'analyzeEmail', data: { displayName, senderEmail, subject, bodyText, links, isEmptyBody, recipientStatus, replyToMismatch } }`
 
 **Background → Content:** `{ verdict: 'Ok'|'Caution'|'Reject', reasons: [...] }` or `{ unavailable: true }`
 
@@ -96,6 +96,7 @@ The banner (`#gsi-banner`) is a compact horizontal strip with three sections sta
 | Verdict pill | `.gsi-pill .gsi-pill-verdict` | Trusted (green), Caution (orange), Dangerous (red) |
 | BCC pill | `.gsi-pill .gsi-pill-warn` | Orange warning, shown when user is BCC'd (hidden by default) |
 | Empty pill | `.gsi-pill .gsi-pill-warn` | Orange warning, shown when email body is empty/near-empty (hidden by default) |
+| Reply-To pill | `.gsi-pill .gsi-pill-fail` | Red warning, shown when Reply-To domain differs from sender domain (hidden by default) |
 | Gemini sparkle | `.gsi-gemini-icon` | 24×24 circle, color matches verdict |
 | Expand arrow | `.gsi-strip-expand` | `▼`/`▲` toggles details panel |
 
@@ -103,11 +104,13 @@ The banner (`#gsi-banner`) is a compact horizontal strip with three sections sta
 
 **Verdict pill states:** `.gsi-pill-trusted` (green), `.gsi-pill-caution` (orange), `.gsi-pill-dangerous` (red).
 
-**Warning pill states:** `.gsi-pill-warn` (orange). Shown conditionally for BCC recipient and empty body detection.
+**Warning pill states:** `.gsi-pill-warn` (orange). Shown conditionally for BCC recipient and empty body detection. `.gsi-pill-fail` (red) used for Reply-To mismatch.
 
 **BCC detection:** Compares user's email (from `Delivered-To` header) against `To` and `Cc` headers. If absent from both, user was BCC'd. Detected via `parseRecipientHeaders()` / `detectBccStatus()` in content.js.
 
 **Empty body detection:** Flagged when `bodyText.trim().length < 10` in `extractEmailData()`.
+
+**Reply-To mismatch detection:** Compares Reply-To header domain (root) against sender From domain (root). If different, shows red pill. Detected via `parseRecipientHeaders()` / `detectReplyToMismatch()` in content.js. Also fed to AI analysis as a high-severity signal.
 
 **Logo-source override:** If the logo chain falls through to caution.svg (source = unknown), the verdict is capped at caution even if SPF/DKIM/DMARC all pass. Coordinated via a shared `bannerState` object.
 
@@ -130,6 +133,7 @@ Always visible below the main strip (not inside the expandable details). Uses Ch
 3. Link domain discrepancies (excluding link shorteners and subdomains)
 4. BCC recipient status (escalates when combined with other signals)
 5. Empty body detection (suspicious from unknown senders)
+6. Reply-To domain mismatch (replies routed to different domain than sender)
 
 #### 3. Details Panel (`.gsi-details-panel`)
 

--- a/src/background.js
+++ b/src/background.js
@@ -223,6 +223,7 @@ Given the email data below, evaluate these criteria:
 3. LINK DISCREPANCIES: Do any links point to domains different from the sender's domain? Note: link shorteners (bit.ly, t.co, goo.gl, tinyurl.com, etc.) and subdomained links (e.g., sender.example.com linking to example.com) are generally acceptable and should NOT be flagged. Personal emails often share links to various sites — this is normal and should NOT be flagged unless the links appear to mimic login pages or financial sites.
 4. BCC RECIPIENT: If "Recipient: BCC" is present, the recipient was blind-copied — they are not in the To or Cc fields. BCC from an unknown sender with no body or a generic subject is highly suspicious (likely spam or phishing probe). BCC alone is not dangerous (newsletters, internal forwards), but combined with other signals (empty body, unknown sender, urgency) it should escalate the verdict.
 5. EMPTY BODY: If "Body: (empty)" is noted, the email has no meaningful content. An empty or near-empty body from an unknown sender is suspicious — legitimate emails almost always contain content. Combined with BCC, this is a strong spam/phishing indicator.
+6. REPLY-TO MISMATCH: If "Reply-To mismatch" data is present, the Reply-To header routes replies to a different domain than the sender's From address. This is the #1 phishing technique — the From address looks legitimate but replies go to an attacker-controlled mailbox. This is a HIGH severity signal that should significantly escalate the verdict toward Caution or Reject, especially combined with urgency language, link discrepancies, or sender mismatch.
 
 AUTHENTICATION CONTEXT: The email data may include SPF, DKIM, and DMARC results. When all three pass, the sender is cryptographically verified — strongly favor "Ok" unless there are clear phishing indicators. However, passing authentication alone does NOT make a BCC'd empty-body email safe — spammers can have valid SPF/DKIM/DMARC. Weigh authentication together with behavioral signals (BCC status, empty body, unknown sender).
 
@@ -323,6 +324,9 @@ function buildAiUserPrompt(data) {
     lines.push('Body: (empty)');
   } else if (data.bodyText) {
     lines.push(`Body (excerpt):\n${sanitizeForPrompt(data.bodyText, 2000)}`);
+  }
+  if (data.replyToMismatch) {
+    lines.push(`Reply-To mismatch: replies go to ${sanitizeForPrompt(data.replyToMismatch.replyToEmail, 320)} (domain: ${sanitizeForPrompt(data.replyToMismatch.replyToDomain, 200)}) instead of sender domain ${sanitizeForPrompt(data.replyToMismatch.senderDomain, 200)}`);
   }
   if (data.auth) {
     lines.push(`Authentication: SPF=${data.auth.spf || 'unknown'}, DKIM=${data.auth.dkim || 'unknown'}, DMARC=${data.auth.dmarc || 'unknown'}`);

--- a/src/content.js
+++ b/src/content.js
@@ -330,8 +330,8 @@
   }
 
   /**
-   * Parse To, Cc, and Delivered-To from raw email headers.
-   * Returns { to, cc, deliveredTo } with raw header values.
+   * Parse To, Cc, Bcc, Delivered-To, and mailing list headers from raw email headers.
+   * Returns { to, cc, bcc, deliveredTo, isMailingList } with raw header values.
    */
   function parseRecipientHeaders(headerText) {
     const unfolded = headerText.replace(/\r?\n[ \t]+/g, ' ');
@@ -343,8 +343,12 @@
         result.to = line.substring('to:'.length).trim();
       } else if (lower.startsWith('cc:')) {
         result.cc = line.substring('cc:'.length).trim();
+      } else if (lower.startsWith('bcc:')) {
+        result.bcc = line.substring('bcc:'.length).trim();
       } else if (lower.startsWith('delivered-to:')) {
         result.deliveredTo = line.substring('delivered-to:'.length).trim().toLowerCase();
+      } else if (lower.startsWith('list-id:') || lower.startsWith('x-google-group-id:') || lower.startsWith('mailing-list:')) {
+        result.isMailingList = true;
       }
     }
     return Object.keys(result).length > 0 ? result : null;
@@ -352,19 +356,31 @@
 
   /**
    * Determine if the current user was BCC'd on this email.
-   * Checks if the user's email appears in To or Cc headers.
+   * Priority: explicit Bcc header > mailing list detection > To/Cc absence heuristic.
    * @param {Object} recipientHeaders - from parseRecipientHeaders or authData
-   * @returns {'bcc'|'direct'|null} - bcc if not found in To/Cc, direct if found, null if unknown
+   * @returns {'bcc'|'direct'|null} - bcc if BCC'd, direct if in To/Cc, null if unknown
    */
   function detectBccStatus(recipientHeaders) {
     if (!recipientHeaders) return null;
     const userEmail = recipientHeaders.deliveredTo;
+
+    // 1. Explicit Bcc header — definitive signal
+    if (recipientHeaders.bcc) {
+      const bccLower = recipientHeaders.bcc.toLowerCase();
+      if (userEmail && bccLower.includes(userEmail)) return 'bcc';
+      // Bcc header present but doesn't contain user — still BCC'd if user not in To/Cc
+      // (Bcc header may be redacted to just the current user's entry)
+    }
+
+    // 2. Mailing list — email arrived via group expansion, not BCC
+    if (recipientHeaders.isMailingList) return 'direct';
+
     if (!userEmail) return null;
 
     const toCc = ((recipientHeaders.to || '') + ' ' + (recipientHeaders.cc || '')).toLowerCase();
     if (!toCc.trim()) return null;
 
-    // Check if user's email appears in To or Cc
+    // 3. Check if user's email appears in To or Cc
     if (toCc.includes(userEmail)) return 'direct';
     // Also check without +alias: user+tag@gmail.com → user@gmail.com
     const atIdx = userEmail.indexOf('@');
@@ -1191,7 +1207,9 @@
             recipientHeaders = {
               to: headerResult.authData.toHeader || '',
               cc: headerResult.authData.ccHeader || '',
+              bcc: headerResult.authData.bccHeader || '',
               deliveredTo: headerResult.authData.deliveredTo || '',
+              isMailingList: headerResult.authData.isMailingList || false,
             };
           } else if (headerResult.headers) {
             recipientHeaders = parseRecipientHeaders(headerResult.headers);

--- a/src/content.js
+++ b/src/content.js
@@ -347,6 +347,8 @@
         result.bcc = line.substring('bcc:'.length).trim();
       } else if (lower.startsWith('delivered-to:')) {
         result.deliveredTo = line.substring('delivered-to:'.length).trim().toLowerCase();
+      } else if (lower.startsWith('reply-to:')) {
+        result.replyTo = line.substring('reply-to:'.length).trim();
       } else if (lower.startsWith('list-id:') || lower.startsWith('x-google-group-id:') || lower.startsWith('mailing-list:')) {
         result.isMailingList = true;
       }
@@ -417,6 +419,51 @@
       }
     }
     return result;
+  }
+
+  // --- Root domain extraction (mirrors background.js) ---
+
+  const MULTI_PART_TLDS = new Set([
+    'co.uk', 'org.uk', 'ac.uk', 'gov.uk', 'me.uk', 'net.uk',
+    'com.au', 'net.au', 'org.au', 'edu.au', 'gov.au',
+    'co.nz', 'net.nz', 'org.nz',
+    'co.in', 'net.in', 'org.in', 'gen.in', 'firm.in', 'ind.in',
+    'co.za', 'org.za', 'web.za',
+    'co.jp', 'or.jp', 'ne.jp', 'ac.jp',
+    'com.br', 'net.br', 'org.br',
+    'com.mx', 'org.mx', 'net.mx',
+    'com.cn', 'net.cn', 'org.cn',
+    'co.kr', 'or.kr', 'ne.kr',
+    'com.sg', 'org.sg', 'net.sg',
+    'com.hk', 'org.hk', 'net.hk',
+    'co.il', 'org.il', 'net.il',
+    'com.tw', 'org.tw', 'net.tw',
+    'com.ar', 'org.ar', 'net.ar',
+    'co.th', 'or.th', 'in.th',
+    'com.tr', 'org.tr', 'net.tr',
+  ]);
+
+  function getRootDomain(domain) {
+    const parts = domain.toLowerCase().split('.');
+    if (parts.length <= 2) return domain.toLowerCase();
+    const lastTwo = parts.slice(-2).join('.');
+    if (MULTI_PART_TLDS.has(lastTwo)) return parts.slice(-3).join('.');
+    return parts.slice(-2).join('.');
+  }
+
+  /**
+   * Detect Reply-To domain mismatch against the sender domain.
+   * Returns { replyToEmail, replyToDomain, senderDomain } if mismatched, or null.
+   */
+  function detectReplyToMismatch(replyTo, senderEmail) {
+    if (!replyTo || !senderEmail) return null;
+    const replyToMatch = replyTo.match(/<([^>]+)>/) || [null, replyTo];
+    const replyToEmail = (replyToMatch[1] || '').toLowerCase().trim();
+    if (!replyToEmail || !replyToEmail.includes('@')) return null;
+    const replyToDomain = getRootDomain(replyToEmail.split('@')[1]);
+    const senderDomain = getRootDomain(senderEmail.split('@')[1]);
+    if (replyToDomain === senderDomain) return null;
+    return { replyToEmail, replyToDomain, senderDomain };
   }
 
   // --- Verdict logic ---
@@ -1012,6 +1059,13 @@
     emptyBodyPill.style.display = 'none';
     stripRow.appendChild(emptyBodyPill);
 
+    const replyToPill = document.createElement('span');
+    replyToPill.classList.add('gsi-pill', 'gsi-pill-fail');
+    replyToPill.textContent = 'REPLY-TO ✗';
+    replyToPill.title = 'Reply-To domain differs from sender domain';
+    replyToPill.style.display = 'none';
+    stripRow.appendChild(replyToPill);
+
     // Spacer
     const spacer = document.createElement('div');
     spacer.style.flex = '1';
@@ -1220,6 +1274,15 @@
             emailData.recipientStatus = 'bcc';
           } else if (bccStatus === 'direct') {
             emailData.recipientStatus = 'direct';
+          }
+
+          // Reply-To mismatch detection
+          const replyToHeader = recipientHeaders?.replyTo;
+          const replyToMismatch = detectReplyToMismatch(replyToHeader, envelopeEmail);
+          if (replyToMismatch) {
+            replyToPill.style.display = '';
+            replyToPill.title = `Replies go to ${replyToMismatch.replyToEmail} (${replyToMismatch.replyToDomain}) instead of sender (${replyToMismatch.senderDomain})`;
+            emailData.replyToMismatch = replyToMismatch;
           }
         }
       }

--- a/src/content.js
+++ b/src/content.js
@@ -1264,6 +1264,7 @@
               bcc: headerResult.authData.bccHeader || '',
               deliveredTo: headerResult.authData.deliveredTo || '',
               isMailingList: headerResult.authData.isMailingList || false,
+              replyTo: headerResult.authData.replyTo || '',
             };
           } else if (headerResult.headers) {
             recipientHeaders = parseRecipientHeaders(headerResult.headers);

--- a/src/content.js
+++ b/src/content.js
@@ -1441,6 +1441,7 @@
           'Authentication-Results',
           'Received-SPF',
           'DKIM-Signature',
+          'Reply-To',
         ]);
         if (rawHeaders['Authentication-Results']) {
           for (const line of rawHeaders['Authentication-Results']) {
@@ -1454,6 +1455,11 @@
         }
         if (rawHeaders['DKIM-Signature']) {
           for (const line of rawHeaders['DKIM-Signature']) {
+            debugLines.push(line);
+          }
+        }
+        if (rawHeaders['Reply-To']) {
+          for (const line of rawHeaders['Reply-To']) {
             debugLines.push(line);
           }
         }
@@ -1471,6 +1477,20 @@
         }
       }
       debugLines.push(`BIMI: ${info.logoSource === 'bimi' ? 'pass (DNS)' : 'none'}`);
+
+      // Reply-To diagnostics
+      let replyToHeader = null;
+      if (result.headers) {
+        const rh = parseRecipientHeaders(result.headers);
+        if (rh) replyToHeader = rh.replyTo;
+      } else if (result.authData?.replyTo) {
+        replyToHeader = result.authData.replyTo;
+      }
+      const replyToMismatch = detectReplyToMismatch(replyToHeader, envelopeEmail);
+      debugLines.push('--- Reply-To ---');
+      debugLines.push(`From: ${envelopeEmail || '(none)'}`);
+      debugLines.push(`Reply-To: ${replyToHeader || '(not set)'}`);
+      debugLines.push(`Mismatch: ${replyToMismatch ? `YES — replies go to ${replyToMismatch.replyToDomain} instead of ${replyToMismatch.senderDomain}` : 'no'}`);
 
       // Profile image diagnostics
       const pd = banner.__gsiProfileDebug;

--- a/src/page-fetch.js
+++ b/src/page-fetch.js
@@ -93,7 +93,7 @@ window.addEventListener('message', async (event) => {
       if (bccMatch) authData.bccHeader = bccMatch[1].trim();
       const deliveredToMatch = stripped.match(/Delivered-To[:\s]+([^\s<]+@[^\s>]+)/i);
       if (deliveredToMatch) authData.deliveredTo = deliveredToMatch[1].toLowerCase().trim();
-      const replyToMatch = stripped.match(/\bReply-To[:\s]+([^\n]+)/i);
+      const replyToMatch = stripped.match(/\bReply-To\s*:\s*([^\n]*@[^\n]*)/i);
       if (replyToMatch) authData.replyTo = replyToMatch[1].trim();
       if (/\b(List-Id|X-Google-Group-Id|Mailing-List)\s*:/i.test(stripped)) {
         authData.isMailingList = true;

--- a/src/page-fetch.js
+++ b/src/page-fetch.js
@@ -84,13 +84,18 @@ window.addEventListener('message', async (event) => {
       const origSenderMatch = stripped.match(/X-Original-Sender[:\s]+([^\s<]+@[^\s>]+)/i);
       if (origSenderMatch) authData.originalSender = origSenderMatch[1].toLowerCase().trim();
 
-      // Extract To, Cc, and Delivered-To for BCC detection
+      // Extract To, Cc, Bcc, Delivered-To, and mailing list headers for BCC detection
       const toMatch = stripped.match(/\bTo[:\s]+([^\n]+)/i);
       if (toMatch) authData.toHeader = toMatch[1].trim();
       const ccMatch = stripped.match(/\bCc[:\s]+([^\n]+)/i);
       if (ccMatch) authData.ccHeader = ccMatch[1].trim();
+      const bccMatch = stripped.match(/\bBcc[:\s]+([^\n]+)/i);
+      if (bccMatch) authData.bccHeader = bccMatch[1].trim();
       const deliveredToMatch = stripped.match(/Delivered-To[:\s]+([^\s<]+@[^\s>]+)/i);
       if (deliveredToMatch) authData.deliveredTo = deliveredToMatch[1].toLowerCase().trim();
+      if (/\b(List-Id|X-Google-Group-Id|Mailing-List)\s*:/i.test(stripped)) {
+        authData.isMailingList = true;
+      }
 
       // Extract raw header lines from the stripped HTML text
       // The full email headers are embedded in the HTML page

--- a/src/page-fetch.js
+++ b/src/page-fetch.js
@@ -93,13 +93,15 @@ window.addEventListener('message', async (event) => {
       if (bccMatch) authData.bccHeader = bccMatch[1].trim();
       const deliveredToMatch = stripped.match(/Delivered-To[:\s]+([^\s<]+@[^\s>]+)/i);
       if (deliveredToMatch) authData.deliveredTo = deliveredToMatch[1].toLowerCase().trim();
+      const replyToMatch = stripped.match(/\bReply-To[:\s]+([^\n]+)/i);
+      if (replyToMatch) authData.replyTo = replyToMatch[1].trim();
       if (/\b(List-Id|X-Google-Group-Id|Mailing-List)\s*:/i.test(stripped)) {
         authData.isMailingList = true;
       }
 
       // Extract raw header lines from the stripped HTML text
       // The full email headers are embedded in the HTML page
-      const headerNames = ['Authentication-Results', 'Received-SPF', 'DKIM-Signature', 'ARC-Authentication-Results'];
+      const headerNames = ['Authentication-Results', 'Received-SPF', 'DKIM-Signature', 'ARC-Authentication-Results', 'Reply-To'];
       const rawHeaderLines = {};
       for (const name of headerNames) {
         const re = new RegExp(name + '\\s*:[^\\n]+', 'gi');


### PR DESCRIPTION
## Summary

Closes #15

- Parses Reply-To header from already-fetched raw email headers via parseRecipientHeaders()
- Compares Reply-To root domain against sender From root domain using new detectReplyToMismatch() function
- Displays a red REPLY-TO pill in the banner strip when domains differ (follows existing BCC/EMPTY pill pattern)
- Feeds mismatch signal into Gemini Nano AI analysis as criterion #6 (high-severity escalation)
- Adds getRootDomain() + MULTI_PART_TLDS to content.js for domain comparison (mirrors background.js)

## Files changed

- src/content.js -- header parsing, domain comparison, UI pill, AI data passthrough
- src/background.js -- AI system prompt (criterion #6), user prompt builder
- CLAUDE.md -- documented new pill, detection logic, and AI criterion

## Permissions impact

None -- uses headers already fetched by fetchEmailHeaders().

## Test plan

- [ ] Load extension unpacked, open an email with a Reply-To header matching the sender domain -- no pill shown
- [ ] Open/craft an email with a Reply-To header pointing to a different root domain -- red REPLY-TO pill visible
- [ ] Hover the Reply-To pill -- tooltip shows the mismatched domains
- [ ] Verify AI analysis references the Reply-To mismatch in its verdict/reasons
- [ ] Verify existing BCC, EMPTY, SPF/DKIM/DMARC pills still work correctly
- [ ] Test with emails that have no Reply-To header -- no pill, no errors
