### PR TITLE
chore: rename git-release skill to release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-release
+name: release
 description: Create a new release for gmail-sender-info. Generates a date-based version, bumps manifest.json, commits, tags, pushes, and creates a GitHub release.
 disable-model-invocation: true
 allowed-tools: Bash(git *), Bash(gh *), Bash(date *), Read, Grep, Edit


### PR DESCRIPTION
## Summary
- Renames `.claude/skills/git-release/` to `.claude/skills/release/` and updates the frontmatter `name:` field to match
- Enables other skills to discover the release skill by its shorter canonical name

## Test plan
- [ ] Verify `/release` skill is discoverable in Claude Code
- [ ] Run `/release` and confirm date-based release flow works as before