### PR TITLE
chore: enable release skill invocation

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: release
 description: Create a new release for gmail-sender-info. Generates a date-based version, bumps manifest.json, commits, tags, pushes, and creates a GitHub release.
-disable-model-invocation: true
 allowed-tools: Bash(git *), Bash(gh *), Bash(date *), Read, Grep, Edit
 ---
 


### PR DESCRIPTION
## Summary
- Removes `disable-model-invocation: true` from the release skill frontmatter
- Allows the Skill tool to invoke `/release` directly in the git-ship-pr workflow
- Fixes recurring issue where the release step was skipped

## Test plan
- [ ] Run `/git-ship-pr` and verify `/release` is invoked automatically at step 6