### PR TITLE
Add review nag bar with engagement gating and snooze/dismiss (#34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,22 @@ Always visible below the main strip (not inside the expandable details). Uses Ch
 5. Empty body detection (suspicious from unknown senders)
 6. Reply-To domain mismatch (replies routed to different domain than sender)
 
+#### 2b. Review Nag (`.gsi-review-nag`)
+
+Conditionally visible below the AI line, above the details panel. Prompts engaged users to leave a Chrome Web Store review.
+
+**Show conditions (all must be true):**
+- No `gsi_review_clicked_at` in storage (permanent dismiss)
+- No `gsi_review_snoozed_at` within last 14 days
+- `gsi_first_use_time` is 7+ days ago (set on first successful sender info lookup)
+- `gsi_email_view_count` >= 10 (incremented on each banner insert)
+
+**User actions:**
+- Click review link → sets `gsi_review_clicked_at`, nag never returns
+- Click X (dismiss) → sets `gsi_review_snoozed_at`, nag returns after 14 days
+
+**Storage keys** (`gsi_first_use_time`, `gsi_email_view_count`, `gsi_review_snoozed_at`, `gsi_review_clicked_at`) are preserved across `chrome.storage.local.clear()` in the `onInstalled` handler.
+
 #### 3. Details Panel (`.gsi-details-panel`)
 
 Hidden by default, toggled by expand arrow. Single-column stacked layout:

--- a/src/background.js
+++ b/src/background.js
@@ -372,8 +372,13 @@ async function setCache(email, data) {
 
 // --- Clear stale cache on install/update ---
 
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.clear();
+chrome.runtime.onInstalled.addListener(async () => {
+  const reviewKeys = ['gsi_first_use_time', 'gsi_email_view_count', 'gsi_review_snoozed_at', 'gsi_review_clicked_at'];
+  const saved = await chrome.storage.local.get(reviewKeys);
+  await chrome.storage.local.clear();
+  if (Object.keys(saved).length > 0) {
+    await chrome.storage.local.set(saved);
+  }
   aiSession = null;
   aiAvailable = null;
   aiResultCache.clear();
@@ -579,6 +584,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
       const info = await resolveLogo(domain);
       await setCache(email, info);
+      chrome.storage.local.get('gsi_first_use_time', (r) => {
+        if (!r.gsi_first_use_time) chrome.storage.local.set({ gsi_first_use_time: Date.now() });
+      });
       sendResponse(info);
     })();
 

--- a/src/content.js
+++ b/src/content.js
@@ -1001,6 +1001,13 @@
     const subjectEl = document.querySelector('.hP');
     if (!subjectEl) return;
 
+    try {
+      chrome.storage.local.get('gsi_email_view_count', (r) => {
+        if (chrome.runtime.lastError) return;
+        chrome.storage.local.set({ gsi_email_view_count: (r.gsi_email_view_count || 0) + 1 });
+      });
+    } catch { /* context invalidated */ }
+
     const banner = document.createElement('div');
     banner.id = 'gsi-banner';
 
@@ -1254,6 +1261,59 @@
     detailsPanel.appendChild(aiDetailsSection);
 
     // 4. Debug section (nested collapsible) — built by original sender / debug async block
+
+    // --- Review nag (below AI line, above details) ---
+    const reviewNagRow = document.createElement('div');
+    reviewNagRow.classList.add('gsi-review-nag');
+    reviewNagRow.style.display = 'none';
+    banner.appendChild(reviewNagRow);
+
+    (async () => {
+      if (!contextValid) return;
+      try {
+        const rs = await new Promise(resolve => {
+          chrome.storage.local.get(
+            ['gsi_first_use_time', 'gsi_email_view_count', 'gsi_review_snoozed_at', 'gsi_review_clicked_at'],
+            resolve
+          );
+        });
+        if (rs.gsi_review_clicked_at) return;
+        if (rs.gsi_review_snoozed_at && (Date.now() - rs.gsi_review_snoozed_at) < 14 * 86400000) return;
+        if (!rs.gsi_first_use_time || (Date.now() - rs.gsi_first_use_time) < 7 * 86400000) return;
+        if ((rs.gsi_email_view_count || 0) < 10) return;
+        if (!banner.isConnected) return;
+
+        const text = document.createElement('span');
+        text.textContent = 'Enjoying Gmail Sender Info? ';
+        const link = document.createElement('a');
+        link.href = `https://chromewebstore.google.com/detail/${chrome.runtime.id}/reviews`;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.classList.add('gsi-review-nag-link');
+        link.textContent = 'Leave a review';
+        link.addEventListener('click', () => {
+          chrome.storage.local.set({ gsi_review_clicked_at: Date.now() });
+          reviewNagRow.remove();
+        });
+        const spacer = document.createElement('div');
+        spacer.style.flex = '1';
+        const dismiss = document.createElement('button');
+        dismiss.classList.add('gsi-review-nag-dismiss');
+        dismiss.type = 'button';
+        dismiss.title = 'Dismiss';
+        dismiss.setAttribute('aria-label', 'Dismiss review prompt');
+        dismiss.textContent = '✕';
+        dismiss.addEventListener('click', () => {
+          chrome.storage.local.set({ gsi_review_snoozed_at: Date.now() });
+          reviewNagRow.remove();
+        });
+        reviewNagRow.appendChild(text);
+        reviewNagRow.appendChild(link);
+        reviewNagRow.appendChild(spacer);
+        reviewNagRow.appendChild(dismiss);
+        reviewNagRow.style.display = '';
+      } catch { /* storage access failed */ }
+    })();
 
     banner.appendChild(detailsPanel);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -375,6 +375,48 @@
   object-fit: contain;
 }
 
+/* --- Review nag row --- */
+
+.gsi-review-nag {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-top: 1px solid #ebebeb;
+  font-size: 12px;
+  color: #5f6368;
+}
+
+.gsi-review-nag-link {
+  color: #1a73e8;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.gsi-review-nag-link:hover {
+  text-decoration: underline;
+}
+
+.gsi-review-nag-dismiss {
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+  color: #9aa0a6;
+  background: none;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.gsi-review-nag-dismiss:hover {
+  background: #e8eaed;
+  color: #3c4043;
+}
+
 .gsi-country-flag {
   font-size: 16px;
   display: inline-block;


### PR DESCRIPTION
Shows a dismissible review prompt in the email banner when:
- 7+ days since first use
- 10+ email views
- Not snoozed within 14 days or permanently dismissed

Clicking the review link permanently suppresses; X snoozes for 14 days.
Review state keys preserved across chrome.storage.local.clear() on update.
