### PR TITLE
Fix AI availability: handle model download, crash recovery, and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-05
 
+- [55cf219](https://github.com/lankeami/gmail-sender-info/commit/55cf219447895d0c2e18d791bbaf8ffe6c9d2b21) Fix AI availability: handle model download, crash recovery, and timeouts
+  - Only treat status "available" as ready (not "downloading"/"downloadable") - Add "Set up AI safety check" button to trigger model download with user gesture (Chrome requires a click to start the ~2GB Gemini Nano download) - Add withTimeout wrapper to prevent LanguageModel.create/clone/prompt from hanging indefinitely (60s create, 30s clone, 60s prompt) - Show user-friendly messages for each unavailable state: downloading, needs restart, timed out - Try LanguageModel.create() directly when availability() returns "unavailable" to get a more specific error message - Check window.ai.languageModel as fallback API path - Bump version to 2026.0805.2012
 - [e40f61a](https://github.com/lankeami/gmail-sender-info/commit/e40f61aa8be9b4a4fd9d21b810dc6f91da6e8b2b) chore: release v20260805.1201
 - [2d0e279](https://github.com/lankeami/gmail-sender-info/commit/2d0e27925478ae07644e9b67cb0689fc1818459f) Fix AI summaries by moving LanguageModel from service worker to MAIN world (#37)
   Chrome Prompt API is no longer available in service workers (removed when API moved from origin trial to stable in Chrome 148+). Moved all AI analysis to page-fetch.js (MAIN world) where LanguageModel is available, using the existing postMessage pattern.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gmail Sender Info",
-  "version": "2026.0805.1201",
+  "version": "2026.0805.2012",
   "description": "Shows sender domain info, logo, and favicon on Gmail inbox rows and email view.",
   "permissions": ["storage"],
   "host_permissions": [

--- a/src/content.js
+++ b/src/content.js
@@ -260,7 +260,7 @@
         else if (authData) resolve({ authData });
         else resolve({ headers });
       }
-    } else if (type === 'gsi-ai-available-result' || type === 'gsi-ai-analysis-result') {
+    } else if (type === 'gsi-ai-available-result' || type === 'gsi-ai-analysis-result' || type === 'gsi-ai-download-result') {
       const resolve = pendingAiRequests.get(requestId);
       if (resolve) {
         pendingAiRequests.delete(requestId);
@@ -852,7 +852,7 @@
           pendingAiRequests.delete(requestId);
           resolve({ timeout: true });
         }
-      }, 30000);
+      }, 90000);
       pendingAiRequests.set(requestId, (resp) => {
         if (settled) return;
         settled = true;
@@ -1365,7 +1365,59 @@
     (async () => {
       const aiStatus = await checkAiAvailable();
 
-      if (!aiStatus.available) return;
+      // Always append AI diagnostics (handles race with debug section builder)
+      const aiDiagLines = [
+        '--- AI Availability ---',
+        `available: ${aiStatus.available}`,
+        `hasApi: ${aiStatus.hasApi}`,
+        `status: ${aiStatus.status}`,
+        `statusError: ${aiStatus.statusError || 'none'}`,
+        `createError: ${aiStatus.createError || 'none'}`,
+        `chromeVersion: ${aiStatus.chromeVersion}`,
+      ];
+      const debugEl = banner.querySelector('.gsi-debug-content');
+      if (debugEl) {
+        debugEl.textContent += '\n' + aiDiagLines.join('\n');
+      } else {
+        banner.__gsiAiDebug = aiDiagLines;
+      }
+
+      if (!aiStatus.available || aiStatus.status === 'downloading' || aiStatus.status === 'downloadable') {
+        aiLine.style.display = '';
+        aiLineText.classList.remove('gsi-ai-line-loading');
+        if (aiStatus.status === 'downloading' || aiStatus.status === 'downloadable') {
+          aiLineText.textContent = '';
+          const dlBtn = document.createElement('button');
+          dlBtn.type = 'button';
+          dlBtn.textContent = 'Set up AI safety check';
+          dlBtn.style.cssText = 'font-size:12px;padding:3px 12px;cursor:pointer;border:1px solid #1a73e8;border-radius:4px;background:#1a73e8;color:#fff;margin-left:6px;font-weight:500';
+          dlBtn.addEventListener('click', () => {
+            dlBtn.disabled = true;
+            dlBtn.style.opacity = '0.6';
+            dlBtn.textContent = 'Downloading model…';
+            const reqId = ++headerRequestId;
+            pendingAiRequests.set(reqId, (resp) => {
+              if (resp.ready) {
+                aiLineText.textContent = 'AI model ready ';
+                dlBtn.textContent = 'Activate';
+                dlBtn.disabled = false;
+                dlBtn.style.opacity = '1';
+                dlBtn.onclick = () => location.reload();
+              } else {
+                dlBtn.disabled = false;
+                dlBtn.style.opacity = '1';
+                dlBtn.textContent = 'Retry setup';
+                aiLineText.textContent = (resp.error || 'Download failed') + ' ';
+              }
+            });
+            window.postMessage({ type: 'gsi-download-ai', requestId: reqId }, '*');
+          });
+          aiLineText.appendChild(dlBtn);
+        } else {
+          aiLineText.textContent = 'AI safety check requires a browser restart to activate';
+        }
+        return;
+      }
 
       // Show Gemini icon in strip and AI summary line
       geminiIcon.style.display = '';
@@ -1464,8 +1516,8 @@
           // Update AI line with failure message
           aiLineText.classList.remove('gsi-ai-line-loading');
           aiLineText.textContent = result && result.timeout
-            ? 'AI analysis timed out'
-            : 'AI analysis unavailable';
+            ? 'AI safety check timed out — try restarting your browser'
+            : 'AI safety check unavailable';
 
           // Add retry button to AI line
           const refreshBtn = document.createElement('button');
@@ -1598,6 +1650,7 @@
       debugContent.classList.add('gsi-debug-content');
       // Build debug lines
       const debugLines = [
+        `GSI version: ${chrome.runtime.getManifest().version}`,
         `envelope: ${envelopeEmail || '(none)'} | X-Original-Sender: ${originalSender || '(not found)'} | path: ${result.authData ? 'HTML' : 'raw'}`,
       ];
 

--- a/src/page-fetch.js
+++ b/src/page-fetch.js
@@ -176,7 +176,7 @@ async function checkAiAvailableLocal() {
       return false;
     }
     const status = await LanguageModel.availability();
-    aiAvailable = status !== 'unavailable';
+    aiAvailable = status === 'available';
     aiAvailableCheckedAt = Date.now();
     return aiAvailable;
   } catch {
@@ -186,14 +186,21 @@ async function checkAiAvailableLocal() {
   }
 }
 
+function withTimeout(promise, ms) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), ms)),
+  ]);
+}
+
 async function getAiSession() {
   if (aiSession) return aiSession;
   if (aiSessionPromise) return aiSessionPromise;
   aiSessionPromise = (async () => {
     try {
-      aiSession = await LanguageModel.create({
+      aiSession = await withTimeout(LanguageModel.create({
         initialPrompts: [{ role: 'system', content: AI_SYSTEM_PROMPT }],
-      });
+      }), 60000);
       return aiSession;
     } catch {
       aiAvailable = false;
@@ -287,13 +294,59 @@ window.addEventListener('message', async (event) => {
   if (event.source !== window) return;
   if (event.data?.type !== 'gsi-check-ai') return;
   const { requestId } = event.data;
-  const hasApi = typeof LanguageModel !== 'undefined';
+  const hasGlobal = typeof LanguageModel !== 'undefined';
+  const hasWindowAi = typeof window.ai?.languageModel !== 'undefined';
   let status = null;
-  if (hasApi) {
-    try { status = await LanguageModel.availability(); } catch { /* ignore */ }
+  let statusError = null;
+  let createError = null;
+  if (hasGlobal) {
+    try { status = await LanguageModel.availability(); } catch (e) { statusError = e.message; }
+  } else if (hasWindowAi) {
+    try { status = await window.ai.languageModel.availability(); } catch (e) { statusError = e.message; }
   }
-  const available = hasApi && status !== 'unavailable' && status !== null;
-  window.postMessage({ type: 'gsi-ai-available-result', requestId, available, hasApi, status }, '*');
+  // If availability says unavailable, try create() directly — it can trigger download
+  // and sometimes works when availability is stale
+  let available = (hasGlobal || hasWindowAi) && status === 'available';
+  if (!available && (hasGlobal || hasWindowAi) && status !== 'downloading' && status !== 'downloadable') {
+    try {
+      const testSession = hasGlobal
+        ? await LanguageModel.create({ initialPrompts: [{ role: 'system', content: 'test' }] })
+        : await window.ai.languageModel.create({ initialPrompts: [{ role: 'system', content: 'test' }] });
+      if (testSession) {
+        testSession.destroy();
+        available = true;
+        aiAvailable = true;
+        status = 'available (via create)';
+      }
+    } catch (e) { createError = e.message; }
+  }
+  const hasApi = hasGlobal || hasWindowAi;
+  console.log('[GSI] AI check:', { hasGlobal, hasWindowAi, status, statusError, createError, available });
+  window.postMessage({ type: 'gsi-ai-available-result', requestId, available, hasApi, status, statusError, createError }, '*');
+});
+
+// User-gesture-triggered download — Chrome requires a click to start the model download
+window.addEventListener('message', async (event) => {
+  if (event.source !== window) return;
+  if (event.data?.type !== 'gsi-download-ai') return;
+  const { requestId } = event.data;
+  try {
+    const session = await LanguageModel.create({
+      monitor(m) {
+        m.addEventListener('downloadprogress', (e) => {
+          console.log('[GSI] AI model download:', Math.round(e.loaded / e.total * 100) + '%');
+        });
+      },
+      initialPrompts: [{ role: 'system', content: 'test' }],
+    });
+    if (session) {
+      session.destroy();
+      aiAvailable = true;
+    }
+    window.postMessage({ type: 'gsi-ai-download-result', requestId, ready: true }, '*');
+  } catch (e) {
+    window.postMessage({ type: 'gsi-ai-download-result', requestId, ready: false, error: e.message }, '*');
+  }
 });
 
 window.addEventListener('message', async (event) => {
@@ -317,11 +370,11 @@ window.addEventListener('message', async (event) => {
   }
 
   async function runPrompt(session, retried) {
-    const clone = await session.clone();
+    const clone = await withTimeout(session.clone(), 30000);
     try {
       const userPrompt = buildAiUserPrompt(data);
       const t0 = Date.now();
-      const rawResponse = await clone.prompt(userPrompt);
+      const rawResponse = await withTimeout(clone.prompt(userPrompt), 60000);
       const durationMs = Date.now() - t0;
       const result = parseAiResult(rawResponse);
       const response = { ...result, debug: { rawResponse, userPrompt, durationMs, cached: false, retried } };


### PR DESCRIPTION
## Summary
- Fixes AI summaries not displaying after Chrome removed LanguageModel from service workers
- Handles all model states: downloading, downloadable, unavailable, crashed
- Adds user-gesture-triggered "Set up AI safety check" button for first-time model download
- Adds timeouts to prevent LanguageModel operations from hanging indefinitely
- Shows user-friendly status messages instead of silent failures

## Test plan
- [ ] Load extension on Chrome 148+ with Gemini Nano not yet downloaded — should show "Set up" button
- [ ] Click "Set up" — model download should start
- [ ] After download completes, reload Gmail — AI summaries should appear
- [ ] On Chrome without Prompt API support — should show restart message, not crash
- [ ] Verify SPF/DKIM/DMARC pills still work independently of AI status